### PR TITLE
Fix MacOS build option

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,8 @@ version: 2.1
 jobs:
   build:
     macos:
-      xcode: 12.3.0
+      xcode: 26.3.0
+    resource_class: m4pro.medium
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,9 @@ jobs:
       xcode: 26.3.0
     resource_class: m4pro.medium
     steps:
-      - checkout
+      - run:
+          name: Checkout
+          command: git clone https://github.com/bmkiefer/dotfiles.git .
       - run:
           name: Run Setup Script
           command: ./setup.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,14 +15,14 @@ jobs:
           name: Verify Installed Tools
           command: |
             source ~/.bash_profile
-            which nvim
-            which nvm
-            which node
-            which tmux
-            which lua
-            which lua-language-server
-            which uv
-            which ruff
-            which pyrefly
-            which claude
+            command -v nvim
+            command -v nvm
+            command -v node
+            command -v tmux
+            command -v lua
+            command -v lua-language-server
+            command -v uv
+            command -v ruff
+            command -v pyrefly
+            command -v claude
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,14 +15,15 @@ jobs:
           name: Verify Installed Tools
           command: |
             source ~/.bash_profile
-            command -v nvim
-            command -v nvm
-            command -v node
-            command -v tmux
+            command -v claude
             command -v lua
             command -v lua-language-server
-            command -v uv
-            command -v ruff
+            command -v node
+            command -v npm
+            command -v nvm
+            command -v nvim
             command -v pyrefly
-            command -v claude
+            command -v ruff
+            command -v tmux
+            command -v uv
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,4 +11,18 @@ jobs:
       - run:
           name: Run Setup Script
           command: ./setup.sh
+      - run:
+          name: Verify Installed Tools
+          command: |
+            source ~/.bash_profile
+            which nvim
+            which nvm
+            which node
+            which tmux
+            which lua
+            which lua-language-server
+            which uv
+            which ruff
+            which pyrefly
+            which claude
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,0 @@
-CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,30 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Overview
+
+Brandon's personal dotfiles for setting up personal development machines. The primary entry point is `setup.sh`, which bootstraps a full development environment from scratch for MacOS.
+
+## Setup
+
+Run from the home directory:
+```bash
+./setup.sh
+```
+
+This installs: Homebrew, Neovim (with config from `bmkiefer/nvim-config`), NVM, Node.js LTS, Tmux, Lua, Lua Language Server, Claude Code CLI, and Python tooling (uv, pyrefly, ruff). It also copies `bash/bash_profile` to `~/.bash_profile` and configures the Context7 MCP server.
+
+## CI
+
+CircleCI (`.circleci/config.yml`) validates `setup.sh` runs successfully on macOS (Xcode 26.3.0, `m4pro.medium`). The pipeline clones the repo via HTTPS (public repo, no SSH key needed), runs `setup.sh`, then verifies all tools are on `PATH` using `command -v`.
+
+## Architecture
+
+- `setup.sh` — single idempotent install script; checks for existing tools before installing
+- `bash/bash_profile` — shell config: NVM init, git branch in prompt, aliases (`vi`/`vim` → `nvim`, `cdd` → `~/code/dotfiles`, `cdn` → `~/.config/nvim`), auto-switching Node versions via `.nvmrc`
+
+## Key Conventions
+
+- Neovim config lives in a separate repo (`bmkiefer/nvim-config`) cloned to `~/.config/nvim`; changes to editor config go there, not here
+- `setup.sh` is designed to be re-runnable; use conditional checks (`if ! command -v ...`) when adding new installs

--- a/bash/bash_profile
+++ b/bash/bash_profile
@@ -1,6 +1,10 @@
+# Add aliases for vi and vim to neovim
 alias vi=nvim
 alias vim=nvim
+
+# Add aliases for cd'ing to neovim config and dotfiles configuration
 alias cdn="cd ~/.config/nvim"
+alias cdd="cd ~/code/dotfiles"
 
 if [ -f ~/.git-completion.bash ]; then
   . ~/.git-completion.bash

--- a/bash/bash_profile
+++ b/bash/bash_profile
@@ -48,7 +48,9 @@ fi
 export BASH_SILENCE_DEPRECATION_WARNING=1
 
 # Add bin to path to allow uv usage
-. "$HOME/.local/bin/env"
+if [ -f "$HOME/.local/bin/env" ]; then
+  . "$HOME/.local/bin/env"
+fi
 
 # Source local private overrides if present
 if [ -f ~/.bash_profile_local ]; then


### PR DESCRIPTION
## Summary

- Updated CircleCI macOS image from Xcode 12.3.0 to 26.3.0 with `m4pro.medium` resource class
- Replaced SSH-based `checkout` step with HTTPS `git clone` to fix public repo access (no SSH key needed)
- Added a tool verification step using `command -v` to confirm all tools are on `PATH` after setup
- Guarded uv env sourcing in `bash_profile` to avoid errors on fresh installs before uv is installed
- Removed `CLAUDE.md` from `.gitignore` and updated it to reflect current setup and CI configuration

## Test plan

- [ ] CircleCI pipeline passes on the branch
- [ ] All tools verified by `command -v` step: claude, lua, lua-language-server, node, npm, nvm, nvim, pyrefly, ruff, tmux, uv

🤖 Generated with [Claude Code](https://claude.com/claude-code)