### PR TITLE
Add ruff install and local bash profile support

### DIFF
--- a/bash/bash_profile
+++ b/bash/bash_profile
@@ -49,3 +49,8 @@ export BASH_SILENCE_DEPRECATION_WARNING=1
 
 # Add bin to path to allow uv usage
 . "$HOME/.local/bin/env"
+
+# Source local private overrides if present
+if [ -f ~/.bash_profile_local ]; then
+  . ~/.bash_profile_local
+fi

--- a/setup.sh
+++ b/setup.sh
@@ -76,3 +76,5 @@ uv python install 3.10.17
 # Install pyrefly as a global utility
 uv tool install pyrefly
 
+# Install ruff linter/formatter
+uv tool install ruff


### PR DESCRIPTION
## Summary
- Installs `ruff` linter/formatter via `uv tool install ruff` in `setup.sh`
- Adds sourcing of `~/.bash_profile_local` at the end of `bash/bash_profile` for private/machine-specific config that shouldn't be committed to the repo

## Test plan
- [x] Run `setup.sh` and confirm `ruff --version` works after completion
- [x] Create `~/.bash_profile_local` with private aliases, run `wbp`, and confirm they are available in the shell

🤖 Generated with [Claude Code](https://claude.com/claude-code)