### PR TITLE
Install Code New Roman Nerd Font

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -67,6 +67,9 @@ brew install hashicorp/tap/terraform-ls
 # Install typescript lsp for neovim
 npm install -g typescript-language-server typescript 
 
+# Install code new roman nerd font
+brew install --cask font-code-new-roman-nerd-font 
+
 # Install context7 MCP for documentation look ups
 claude mcp add --transport http context7 https://mcp.context7.com/mcp
 


### PR DESCRIPTION
Neovim requires a Nerd Font to render icons and glyphs correctly. This adds the Code New Roman Nerd Font to the setup so new machines have a compatible font available out of the box.

Installs [`font-code-new-roman-nerd-font`](https://github.com/bmkiefer/dotfiles/blob/bmkiefer/code-new-roman-install/setup.sh#L70) via `brew install --cask`.