### PR TITLE
Add Ghostty terminal install and configuration

### DIFF
--- a/bash/bash_profile
+++ b/bash/bash_profile
@@ -9,6 +9,11 @@ alias cdc="cd ~/code"
 
 # Command to copy and source new bash profile from this repo
 alias wbp="cp ~/code/dotfiles/bash/bash_profile ~/.bash_profile && source ~/.bash_profile"
+# Command to copy and source new ghostty config from this repo
+alias wgc="cp ~/code/dotfiles/ghostty/config ~/.config/ghostty/config"
+
+# Shorten typing for claude
+alias c="claude"
 
 if [ -f ~/.git-completion.bash ]; then
   . ~/.git-completion.bash
@@ -20,7 +25,7 @@ parse_git_branch() {
 }
 
 # Customize PS1
-export PS1="[\[\033[32m\]\t\[\033[00m\]] \[\033[31m\]brandon\[\033[00m\] [\[\033[36m\]\w\[\033[00m\]]\[\033[95m\]\$(parse_git_branch)\[\033[00m\] $ "
+export PS1="[\[\033[38;2;100;255;100m\]\t\[\033[00m\]] \[\033[38;2;255;100;120m\]brandon\[\033[00m\] [\[\033[38;2;100;255;230m\]\w\[\033[00m\]]\[\033[38;2;255;150;255m\]\$(parse_git_branch)\[\033[00m\] $ "
 
 # Add nvm to path
 export NVM_DIR="$HOME/.nvm"

--- a/ghostty/config
+++ b/ghostty/config
@@ -1,0 +1,10 @@
+command = /bin/bash --login
+
+font-family = CodeNewRomanNFM
+font-size = 10
+
+theme = Catppuccin Mocha
+
+cursor-style-blink = false
+
+macos-option-as-alt = true

--- a/setup.sh
+++ b/setup.sh
@@ -70,6 +70,9 @@ npm install -g typescript-language-server typescript
 # Install code new roman nerd font
 brew install --cask font-code-new-roman-nerd-font 
 
+# Install ghostty terminal
+brew install --cask ghostty
+
 # Install context7 MCP for documentation look ups
 claude mcp add --transport http context7 https://mcp.context7.com/mcp
 


### PR DESCRIPTION
Switching to Ghostty as the primary terminal emulator. The Mac Terminal.app Pro profile was used as a starting point, but the PS1 colors were upgraded to 24-bit RGB for better readability against dark themes like Catppuccin Mocha.

Adds a Ghostty [config](https://github.com/bmkiefer/dotfiles/blob/bmkiefer/install-ghostty/ghostty/config) tracked in the repo with Catppuccin Mocha theme, CodeNewRomanNFM font, and non-blinking cursor. Ghostty is installed via `brew install --cask ghostty` in [`setup.sh`](https://github.com/bmkiefer/dotfiles/blob/bmkiefer/install-ghostty/setup.sh#L73). A `wgc` alias in [`bash_profile`](https://github.com/bmkiefer/dotfiles/blob/bmkiefer/install-ghostty/bash/bash_profile#L13) deploys the config to `~/.config/ghostty/config`, mirroring the existing `wbp` pattern.

## Test plan
- [ ] Run `setup.sh` and verify Ghostty installs via brew
- [ ] Run `wgc` and confirm config is copied to `~/.config/ghostty/config`
- [ ] Open Ghostty and verify Catppuccin Mocha theme, font, and PS1 colors render correctly
- [ ] Verify cursor does not blink