### PR TITLE
Add Ghostty terminal configuration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,8 @@ CircleCI (`.circleci/config.yml`) validates `setup.sh` runs successfully on macO
 ## Architecture
 
 - `setup.sh` — single idempotent install script; checks for existing tools before installing
-- `bash/bash_profile` — shell config: NVM init, git branch in prompt, aliases (`vi`/`vim` → `nvim`, `cdd` → `~/code/dotfiles`, `cdn` → `~/.config/nvim`), auto-switching Node versions via `.nvmrc`
+- `bash/bash_profile` — shell config: NVM init, git branch in prompt, aliases (`vi`/`vim` → `nvim`, `cdd` → `~/code/dotfiles`, `cdn` → `~/.config/nvim`, `wbp` copies bash_profile, `wgc` copies Ghostty config), auto-switching Node versions via `.nvmrc`
+- `ghostty/config` — Ghostty terminal config (Catppuccin Mocha theme, Code New Roman font, split border settings); copied to `~/.config/ghostty/config` by `setup.sh` or the `wgc` alias
 
 ## Key Conventions
 

--- a/bash/bash_profile
+++ b/bash/bash_profile
@@ -10,6 +10,9 @@ alias cdc="cd ~/code"
 # Command to copy and source new bash profile from this repo
 alias wbp="cp ~/code/dotfiles/bash/bash_profile ~/.bash_profile && source ~/.bash_profile"
 
+# Command to copy ghostty config from this repo
+alias wgc="cp ~/code/dotfiles/ghostty/config ~/.config/ghostty/config"
+
 if [ -f ~/.git-completion.bash ]; then
   . ~/.git-completion.bash
 fi

--- a/ghostty/config
+++ b/ghostty/config
@@ -1,0 +1,17 @@
+command = /bin/bash --login
+
+font-family = CodeNewRomanNFM
+font-size = 10
+
+theme = Catppuccin Mocha
+
+cursor-style-blink = false
+
+macos-option-as-alt = true
+
+# Don't dim inactive panes
+unfocused-split-opacity = 1.0
+unfocused-split-fill = #1e1e2e
+
+# Catppuccin Mocha lavender for the split divider
+split-divider-color = #b4befe

--- a/setup.sh
+++ b/setup.sh
@@ -19,6 +19,11 @@ cp bash/bash_profile ~/.bash_profile
 # Source bash_profile
 source ~/.bash_profile
 
+# Copy Ghostty config
+fancy_echo "Copying Ghostty Configuration..."
+mkdir -p ~/.config/ghostty
+cp ghostty/config ~/.config/ghostty/config
+
 # INSTALL DEPENDENCIES
 
 # Download git autocomplete executable


### PR DESCRIPTION
Ghostty is going to be the terminal of choice. This adds it to the dotfiles repo so it's versioned and portable across machines.

Adds a [`ghostty/config`](https://github.com/bmkiefer/dotfiles/blob/ghostty-split-border/ghostty/config) with:
- Catppuccin Mocha theme
- Code New Roman font
- Split pane settings — `unfocused-split-opacity` and `unfocused-split-fill` to prevent inactive pane dimming (workaround for a [known Ghostty 1.2.0+ regression](https://github.com/ghostty-org/ghostty/discussions/8732)), plus `split-divider-color` set to lavender

Integrates into the existing workflow:
- [`setup.sh`](https://github.com/bmkiefer/dotfiles/blob/ghostty-split-border/setup.sh#L22-L25) copies the config to `~/.config/ghostty/config` during bootstrap
- [`bash/bash_profile`](https://github.com/bmkiefer/dotfiles/blob/ghostty-split-border/bash/bash_profile#L13-L14) adds a `wgc` alias for quick config updates
- `CLAUDE.md` updated to document the new file and aliases