### PR TITLE
Add Claude CLAUDE.md configuration to dotfiles

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ Run from the home directory:
 ./setup.sh
 ```
 
-This installs: Homebrew, Neovim (with config from `bmkiefer/nvim-config`), NVM, Node.js LTS, Tmux, Lua, Lua Language Server, Claude Code CLI, and Python tooling (uv, pyrefly, ruff). It also copies `bash/bash_profile` to `~/.bash_profile` and configures the Context7 MCP server.
+This installs: Homebrew, Neovim (with config from `bmkiefer/nvim-config`), NVM, Node.js LTS, Tmux, Lua, Lua Language Server, Claude Code CLI, and Python tooling (uv, pyrefly, ruff). It also copies `bash/bash_profile` to `~/.bash_profile`, copies `claude/CLAUDE.md` to `~/.claude/CLAUDE.md`, and configures the Context7 MCP server.
 
 ## CI
 
@@ -22,8 +22,9 @@ CircleCI (`.circleci/config.yml`) validates `setup.sh` runs successfully on macO
 ## Architecture
 
 - `setup.sh` — single idempotent install script; checks for existing tools before installing
-- `bash/bash_profile` — shell config: NVM init, git branch in prompt, aliases (`vi`/`vim` → `nvim`, `cdd` → `~/code/dotfiles`, `cdn` → `~/.config/nvim`, `wbp` copies bash_profile, `wgc` copies Ghostty config), auto-switching Node versions via `.nvmrc`
+- `bash/bash_profile` — shell config: NVM init, git branch in prompt, aliases (`vi`/`vim` → `nvim`, `cdd` → `~/code/dotfiles`, `cdn` → `~/.config/nvim`, `wbp` copies bash_profile, `wgc` copies Ghostty config, `wcl` copies Claude config), auto-switching Node versions via `.nvmrc`
 - `ghostty/config` — Ghostty terminal config (Catppuccin Mocha theme, Code New Roman font, split border settings); copied to `~/.config/ghostty/config` by `setup.sh` or the `wgc` alias
+- `claude/CLAUDE.md` — global Claude Code configuration (communication style, GitHub interaction rules, code style preferences); copied to `~/.claude/CLAUDE.md` by `setup.sh` or the `wcl` alias
 
 ## Key Conventions
 

--- a/bash/bash_profile
+++ b/bash/bash_profile
@@ -11,12 +11,11 @@ alias cdc="cd ~/code"
 alias wbp="cp ~/code/dotfiles/bash/bash_profile ~/.bash_profile && source ~/.bash_profile"
 # Command to copy and source new ghostty config from this repo
 alias wgc="cp ~/code/dotfiles/ghostty/config ~/.config/ghostty/config"
+# Command to copy Claude CLAUDE.md from this repo
+alias wcl="cp ~/code/dotfiles/claude/CLAUDE.md ~/.claude/CLAUDE.md"
 
 # Shorten typing for claude
 alias c="claude"
-
-# Command to copy ghostty config from this repo
-alias wgc="cp ~/code/dotfiles/ghostty/config ~/.config/ghostty/config"
 
 if [ -f ~/.git-completion.bash ]; then
   . ~/.git-completion.bash

--- a/bash/bash_profile
+++ b/bash/bash_profile
@@ -11,10 +11,10 @@ alias cdc="cd ~/code"
 alias wbp="cp ~/code/dotfiles/bash/bash_profile ~/.bash_profile && source ~/.bash_profile"
 # Command to copy and source new ghostty config from this repo
 alias wgc="cp ~/code/dotfiles/ghostty/config ~/.config/ghostty/config"
-# Command to copy Claude CLAUDE.md from this repo
+# Command to copy global CLAUDE.md from this repo
 alias wcl="cp ~/code/dotfiles/claude/CLAUDE.md ~/.claude/CLAUDE.md"
 
-# Shorten typing for claude
+# Shorten alias for claude
 alias c="claude"
 
 if [ -f ~/.git-completion.bash ]; then

--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -1,6 +1,6 @@
 ## Communication style
 
-- Call out uncertainity briefly instead of guessing.
+- Call out uncertainty briefly instead of guessing.
 - Be concise.
 - Be more concise.
 - Be direct.
@@ -17,7 +17,7 @@
 ## Source code references
 
 - When describing code to me, always give me a GitHub link to source.
-- When create GitHub pull request descriptions always link to code locations when referencing something.
+- When creating GitHub pull request descriptions, always link to code locations when referencing something.
 
 ## Code style
 

--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -1,0 +1,28 @@
+## Communication style
+
+- Call out uncertainity briefly instead of guessing.
+- Be concise.
+- Be more concise.
+- Be direct.
+- Do not give long background explanations unless asked.
+- When offering a recommendation, give the recommendation first.
+
+## GitHub Interactions
+
+- Never respond to comments on pull requests. You can help me craft responses, but do not respond directly.
+- Use the style of why, what, how for pull request descriptions. I don't want why, what, and how as bullets though. Draft your descriptions around this.
+- Never update descriptions of PRs that I do not own. It is not appropriate to do that.
+- Do not add generated with Claude Code to the pull request descriptions. It is noisy.
+
+## Source code references
+
+- When describing code to me, always give me a GitHub link to source.
+- When create GitHub pull request descriptions always link to code locations when referencing something.
+
+## Code style
+
+- Never import within functions or classes. Always import at the top level unless we need to do it for circular dependency reasons.
+- All file imports should be at the top of the file unless there is a strong reason not to do that.
+- Never create boolean conditions that have more than 2 terms. Abstract these out in a variable and use that to branch.
+- Never nest functions inside of our functions. That is difficult to resaon about and it makes the inner function impossible to test.
+- Never use magic numbers or strings. Always create constants that can be reused to make the code cleaner.

--- a/setup.sh
+++ b/setup.sh
@@ -24,6 +24,11 @@ fancy_echo "Copying Ghostty Configuration..."
 mkdir -p ~/.config/ghostty
 cp ghostty/config ~/.config/ghostty/config
 
+# Copy Claude CLAUDE.md
+fancy_echo "Copying Claude Configuration..."
+mkdir -p ~/.claude
+cp claude/CLAUDE.md ~/.claude/CLAUDE.md
+
 # INSTALL DEPENDENCIES
 
 # Download git autocomplete executable


### PR DESCRIPTION
The global `~/.claude/CLAUDE.md` file defines how Claude Code behaves across all projects — communication style, GitHub interaction rules, code style preferences. Without source control, these preferences would be lost on a fresh machine setup and can't be tracked over time.

Source controls the global Claude Code `CLAUDE.md` by adding it to the dotfiles repo at [`claude/CLAUDE.md`](https://github.com/bmkiefer/dotfiles/blob/bmkiefer/source-control-claude-file/claude/CLAUDE.md), with a `wcl` alias to deploy it and a setup step to copy it on bootstrap.

- [`claude/CLAUDE.md`](https://github.com/bmkiefer/dotfiles/blob/bmkiefer/source-control-claude-file/claude/CLAUDE.md) — the source-controlled copy of the global Claude config
- [`bash/bash_profile`](https://github.com/bmkiefer/dotfiles/blob/bmkiefer/source-control-claude-file/bash/bash_profile#L14) — adds the `wcl` alias (copies `claude/CLAUDE.md` → `~/.claude/CLAUDE.md`), also removes a duplicate `wgc` alias
- [`setup.sh`](https://github.com/bmkiefer/dotfiles/blob/bmkiefer/source-control-claude-file/setup.sh#L28-L30) — creates `~/.claude/` and copies the config during initial machine bootstrap