### PR TITLE
Add more code style direction to global CLAUDE.md

### DIFF
--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -35,4 +35,4 @@
 
 #### Tests
 
-- All shared test helpers should go at the bottom of the file. Optimize for the test files being the things that are shown first.
+- All shared test helpers should go at the bottom of the file. Optimize for the tests being the things that are shown first.

--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -27,4 +27,12 @@
 - Never nest functions inside of our functions. That is difficult to resaon about and it makes the inner function impossible to test.
 - Never use magic numbers or strings. Always create constants that can be reused to make the code cleaner.
 - Always type your parameters and return types when using a typed language or a typed variant of a language.
-- When using typing, do not use the `any` type unless you have no other option. Call this out when you do.
+- When using typing, do not use the any type unless you have no other option. Call out when you use any.
+- File level constants should always be below the imports and never littered within the file.
+- Never add lint ignores when creating new code. If you have no other choice, add a NOTE comment to explaining why it is necessary.
+- Do not use break or continue mechanisms when looping. Always find a way to have a consistent control flow.
+- Never create functions with multiple return statements. Centralize returns to a single statement to make control flow cleaner.
+
+#### Tests
+
+- All shared test helpers should go at the bottom of the file. Optimize for the test files being the things that are shown first.


### PR DESCRIPTION
Captures additional code style preferences that have come up repeatedly so Claude follows them by default instead of needing in-the-moment correction. Extends the Code style section in [`claude/CLAUDE.md`](../blob/bmkiefer/more-claude-direction/claude/CLAUDE.md) with rules covering `any`-type call-outs, file-level constant placement, lint ignores, loop control flow, and single return statements. Adds a new Tests subsection with guidance to push shared test helpers to the bottom of the file.

Tasks:

- Reworded the existing `any` rule to "Call out when you use any" for clarity.
- Added bullets for file-level constant placement, avoiding lint ignores (with a NOTE-comment escape hatch), avoiding `break`/`continue`, and avoiding multiple return statements.
- Introduced a `#### Tests` subsection with the shared-helpers-at-bottom rule.

## Test plan

- [x] Re-read the Code style and Tests sections to confirm tone is consistent with surrounding bullets.