### PR TITLE
Add super+i keybind for left split in Ghostty

### DIFF
--- a/ghostty/config
+++ b/ghostty/config
@@ -15,3 +15,5 @@ unfocused-split-fill = #1e1e2e
 
 # Catppuccin Mocha lavender for the split divider
 split-divider-color = #b4befe
+
+keybind = super+i=new_split:left


### PR DESCRIPTION
## Why

Ghostty doesn't ship a default keybind for splitting a pane to the left.

## What

Adds that functionality by mapping `super+i` to `new_split:left` in [`ghostty/config`](../blob/bmkiefer/ghostty-split-left/ghostty/config).

## How

Appended `keybind = super+i=new_split:left` below the existing split-related settings so all split config stays grouped.

## Test plan

- [ ] Copy the config (`wgc`) and reload Ghostty.
- [ ] Press `super+i` and confirm a new split opens to the left of the current pane.