### PR TITLE
Add comment format rule to global CLAUDE.md

### DIFF
--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -32,6 +32,7 @@
 - Never add lint ignores when creating new code. If you have no other choice, add a NOTE comment to explaining why it is necessary.
 - Do not use break or continue mechanisms when looping. Always find a way to have a consistent control flow.
 - Never create functions with multiple return statements. Centralize returns to a single statement to make control flow cleaner.
+- Prefer eliminating special-case branches over handling them. When a conditional looks necessary, ask whether restructuring the data or logic could remove it entirely.
 
 #### Tests
 

--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -33,6 +33,7 @@
 - Do not use break or continue mechanisms when looping. Always find a way to have a consistent control flow.
 - Never create functions with multiple return statements. Centralize returns to a single statement to make control flow cleaner.
 - Prefer eliminating special-case branches over handling them. When a conditional looks necessary, ask whether restructuring the data or logic could remove it entirely.
+- When I ask you to add a comment, use the format `NOTE(bmkiefer MM-DD-YYYY): <message>` or `TODO(bmkiefer MM-DD-YYYY): <message>`, with the comment prefix appropriate to the language (e.g. `#` for Python/shell, `//` for JavaScript/TypeScript/Go/Rust). Use today's date.
 
 #### Tests
 

--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -10,7 +10,7 @@
 ## GitHub Interactions
 
 - Never respond to comments on pull requests. You can help me craft responses, but do not respond directly.
-- Use the style of why, what, how for pull request descriptions. I don't want why, what, and how as bullets though. Draft your descriptions around this.
+- Use the style of why, what, how for pull request descriptions. I don't want why, what, and how as bullets or headers though. Draft your descriptions around this idea.
 - Never update descriptions of PRs that I do not own. It is not appropriate to do that.
 - Do not add generated with Claude Code to the pull request descriptions. It is noisy.
 


### PR DESCRIPTION
## Why

When asking Claude to add an inline comment, I want a consistent, attributable format with a date so future-me knows who wrote a NOTE/TODO and when.

## How

Adds a bullet to the Code style section of [`claude/CLAUDE.md`](../blob/bmkiefer/comment-format-rule/claude/CLAUDE.md#L36) instructing Claude to use `NOTE(bmkiefer MM-DD-YYYY): <message>` or `TODO(bmkiefer MM-DD-YYYY): <message>` with the language-appropriate comment prefix and today's date. Placed directly below the "good taste" rule per request.

This PR is based on `bmkiefer/good-taste-rule` since that branch isn't merged yet.

## Test plan

- [ ] Ask Claude to add a comment in a Python and a TypeScript file; confirm the format and prefix are correct.