### PR TITLE
Sync Claude config and add reviewer-feedback rules

### DIFF
--- a/bash/bash_profile
+++ b/bash/bash_profile
@@ -11,8 +11,8 @@ alias cdc="cd ~/code"
 alias wbp="cp ~/code/dotfiles/bash/bash_profile ~/.bash_profile && source ~/.bash_profile"
 # Command to copy and source new ghostty config from this repo
 alias wgc="cp ~/code/dotfiles/ghostty/config ~/.config/ghostty/config"
-# Command to copy global CLAUDE.md from this repo
-alias wcl="cp ~/code/dotfiles/claude/CLAUDE.md ~/.claude/CLAUDE.md"
+# Command to copy global Claude config from this repo
+alias wcl="cp ~/code/dotfiles/claude/CLAUDE.md ~/.claude/CLAUDE.md && cp ~/code/dotfiles/claude/settings.json ~/.claude/settings.json && cp -p ~/code/dotfiles/claude/statusline.sh ~/.claude/statusline.sh"
 
 # Shorten alias for claude
 alias c="claude"

--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -13,6 +13,7 @@
 - Use the style of why, what, how for pull request descriptions. I don't want why, what, and how as bullets or headers though. Draft your descriptions around this idea.
 - Never update descriptions of PRs that I do not own. It is not appropriate to do that.
 - Do not add generated with Claude Code to the pull request descriptions. It is noisy.
+- When we start going through feedback from reviewers on my Pull requests, always output text in the format of raw comment text, any of your commentary and the currently draft response.
 
 ## Source code references
 
@@ -37,4 +38,5 @@
 
 #### Tests
 
+- Do not mock any seams that aren't explicitly called out. Centralized mock classes should be used if they are necessary.
 - All shared test helpers should go at the bottom of the file. Optimize for the tests being the things that are shown first.

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -1,0 +1,12 @@
+{
+  "model": "opus[1m]",
+  "enabledPlugins": {
+    "figma@claude-plugins-official": true
+  },
+  "effortLevel": "medium",
+  "theme": "dark-ansi",
+  "statusLine": {
+    "type": "command",
+    "command": "bash ~/.claude/statusline.sh"
+  }
+}

--- a/claude/statusline.sh
+++ b/claude/statusline.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+
+# Claude Code Status Line Script
+# Shows: model, context slider + %, tokens used, directory, git branch
+# Colors: Catppuccin Mocha
+
+input=$(cat)
+
+# Catppuccin Mocha palette (24-bit truecolor)
+C_TEXT=$'\033[38;2;205;214;244m'      # #cdd6f4
+C_SUBTEXT=$'\033[38;2;166;173;200m'   # #a6adc8 (subtext0)
+C_OVERLAY=$'\033[38;2;108;112;134m'   # #6c7086 (overlay0)
+C_SURFACE=$'\033[38;2;69;71;90m'      # #45475a (surface1)
+C_MAUVE=$'\033[38;2;203;166;247m'     # #cba6f7
+C_BLUE=$'\033[38;2;137;180;250m'      # #89b4fa
+C_GREEN=$'\033[38;2;166;227;161m'     # #a6e3a1
+C_YELLOW=$'\033[38;2;249;226;175m'    # #f9e2af
+C_RED=$'\033[38;2;243;139;168m'       # #f38ba8
+C_PEACH=$'\033[38;2;250;179;135m'     # #fab387
+C_TEAL=$'\033[38;2;148;226;213m'      # #94e2d5
+RESET=$'\033[0m'
+
+BAR_WIDTH=14
+TOTAL_TOKENS=200000
+THRESHOLD_WARN=50
+THRESHOLD_CRIT=75
+
+get_used_tokens() {
+    local transcript="$1"
+    local tokens=0
+    if [[ -n "$transcript" && -f "$transcript" ]]; then
+        tokens=$(tail -r "$transcript" 2>/dev/null \
+            | jq -r 'select(.message.usage) | (.message.usage.input_tokens // 0) + (.message.usage.cache_read_input_tokens // 0) + (.message.usage.cache_creation_input_tokens // 0) + (.message.usage.output_tokens // 0)' \
+            | head -n 1)
+    fi
+    echo "${tokens:-0}"
+}
+
+pick_bar_color() {
+    local pct="$1"
+    if (( pct >= THRESHOLD_CRIT )); then
+        echo "$C_RED"
+    elif (( pct >= THRESHOLD_WARN )); then
+        echo "$C_YELLOW"
+    else
+        echo "$C_GREEN"
+    fi
+}
+
+render_bar() {
+    local pct="$1"
+    local color="$2"
+    local filled=$(( pct * BAR_WIDTH / 100 ))
+    (( filled > BAR_WIDTH )) && filled=$BAR_WIDTH
+    local empty=$(( BAR_WIDTH - filled ))
+    local bar=""
+    local i
+    for (( i = 0; i < filled; i++ )); do bar+="█"; done
+    local rest=""
+    for (( i = 0; i < empty; i++ )); do rest+="░"; done
+    printf "%s%s%s%s%s" "$color" "$bar" "$C_SURFACE" "$rest" "$RESET"
+}
+
+format_tokens() {
+    local n="$1"
+    if (( n >= 1000 )); then
+        awk -v n="$n" 'BEGIN { printf "%.1fk", n/1000 }'
+    else
+        echo "$n"
+    fi
+}
+
+model=$(echo "$input" | jq -r '.model.display_name // "unknown"')
+transcript=$(echo "$input" | jq -r '.transcript_path // ""')
+current_dir=$(echo "$input" | jq -r '.workspace.current_dir // "."')
+dir_name="${current_dir/#$HOME/~}"
+git_branch=$(git -C "$current_dir" branch --no-color 2>/dev/null | grep '^*' | sed 's/* //')
+
+used_tokens=$(get_used_tokens "$transcript")
+percentage=$(( used_tokens * 100 / TOTAL_TOKENS ))
+bar_color=$(pick_bar_color "$percentage")
+bar=$(render_bar "$percentage" "$bar_color")
+used_fmt=$(format_tokens "$used_tokens")
+total_fmt=$(format_tokens "$TOTAL_TOKENS")
+
+sep="${C_OVERLAY}│${RESET}"
+model_part="${C_MAUVE}${model}${RESET}"
+ctx_part="${bar} ${bar_color}${percentage}%${RESET} ${C_SUBTEXT}${used_fmt}/${total_fmt}${RESET}"
+dir_part="${C_BLUE}${dir_name}${RESET}"
+
+if [[ -n "$git_branch" ]]; then
+    branch_part=" ${C_OVERLAY}(${C_TEAL}${git_branch}${C_OVERLAY})${RESET}"
+else
+    branch_part=""
+fi
+
+printf "%s %s %s %s %s%s\n" "$model_part" "$sep" "$ctx_part" "$sep" "$dir_part" "$branch_part"

--- a/setup_mac.sh
+++ b/setup_mac.sh
@@ -28,6 +28,8 @@ cp ghostty/config ~/.config/ghostty/config
 fancy_echo "Copying Claude Configuration..."
 mkdir -p ~/.claude
 cp claude/CLAUDE.md ~/.claude/CLAUDE.md
+cp claude/settings.json ~/.claude/settings.json
+cp -p claude/statusline.sh ~/.claude/statusline.sh
 
 # INSTALL DEPENDENCIES
 

--- a/setup_mac.sh
+++ b/setup_mac.sh
@@ -83,6 +83,9 @@ brew install --cask font-code-new-roman-nerd-font
 # Install ghostty terminal
 brew install --cask ghostty
 
+# Install jq for claude status line
+brew install jq
+
 # Install context7 MCP for documentation look ups
 claude mcp add --transport http context7 https://mcp.context7.com/mcp
 


### PR DESCRIPTION
My local ~/.claude setup had drifted from the repo: the statusline script and settings.json lived only on my machine, and I had picked up a couple of CLAUDE.md rules I wanted captured. This PR brings everything back under version control.

The repo now ships `~/.claude/statusline.s`h and ~/.claude/settings.json (neither contains anything business-specific), adds two new global CLAUDE.md rules — one covering how I want reviewer feedback formatted, and one tightening test-mocking guidance — and adds `jq` to the brew installs since the statusline depends on it. setup_mac.sh and the `wcl` alias now copy all three Claude files (CLAUDE.md, settings.json, statusline.sh) into ~/.claude.

The statusline script is committed with its executable bit set, and both setup_mac.sh and `wcl` use `cp -p` when copying it so the mode is preserved on install rather than relying on a follow-up `chmod`.