### PR TITLE
Resolve stale transcript paths in statusline

### DIFF
--- a/claude/statusline.sh
+++ b/claude/statusline.sh
@@ -25,6 +25,23 @@ TOTAL_TOKENS=200000
 THRESHOLD_WARN=50
 THRESHOLD_CRIT=75
 
+resolve_transcript() {
+    local payload="$1"
+    local reported
+    reported=$(echo "$payload" | jq -r '.transcript_path // ""')
+    local resolved=""
+    if [[ -n "$reported" && -f "$reported" ]]; then
+        resolved="$reported"
+    else
+        local session_id
+        session_id=$(basename "$reported" .jsonl 2>/dev/null)
+        if [[ -n "$session_id" ]]; then
+            resolved=$(ls -t "$HOME/.claude/projects/"*/"${session_id}.jsonl" 2>/dev/null | head -n 1)
+        fi
+    fi
+    echo "$resolved"
+}
+
 get_used_tokens() {
     local transcript="$1"
     local tokens=0
@@ -71,7 +88,7 @@ format_tokens() {
 }
 
 model=$(echo "$input" | jq -r '.model.display_name // "unknown"')
-transcript=$(echo "$input" | jq -r '.transcript_path // ""')
+transcript=$(resolve_transcript "$input")
 current_dir=$(echo "$input" | jq -r '.workspace.current_dir // "."')
 dir_name="${current_dir/#$HOME/~}"
 git_branch=$(git -C "$current_dir" branch --no-color 2>/dev/null | grep '^*' | sed 's/* //')


### PR DESCRIPTION
The reported `transcript_path` from Claude Code can point at a file that no longer exists on disk — usually because the session was started in a different workspace and the project directory under `~/.claude/projects/` has since been renamed or relocated. When that happens the statusline silently shows `0/200.0k` because [`get_used_tokens`](https://github.com/bmkiefer/dotfiles/blob/master/claude/statusline.sh#L60) bails on the missing file.

To fix that, [`resolve_transcript`](https://github.com/bmkiefer/dotfiles/blob/master/claude/statusline.sh#L28-L44) now takes the raw status payload, parses `transcript_path` itself, and if the reported path is missing falls back to globbing `~/.claude/projects/*/<session_id>.jsonl` for the most recently modified match. The call site at [statusline.sh:91](https://github.com/bmkiefer/dotfiles/blob/master/claude/statusline.sh#L91) collapses to a single `resolve_transcript "$input"`.

Verified locally by piping three crafted payloads through the script: a valid path renders the token bar, a stale path with a real session id resolves to the same file and renders identical token counts, and an empty payload renders `0/200.0k` without errors.