### PR TITLE
Add super+r keybind for reverse search in Ghostty

### DIFF
--- a/ghostty/config
+++ b/ghostty/config
@@ -17,3 +17,4 @@ unfocused-split-fill = #1e1e2e
 split-divider-color = #b4befe
 
 keybind = super+i=new_split:left
+keybind = super+r=text:\x12


### PR DESCRIPTION
Ctrl+R for reverse-i-search is awkward on Mac because both keys land under the same finger. Binding super+r to send the Ctrl+R byte (\x12) lets the left hand and right trigger search via cmd+r. The right hand presses command with the thumb and the left hand presses r with the pointer finger.

Adds a single keybind to ghostty/config that maps super+r to the text action sending \x12, which the shell interprets as Ctrl+R.

Reload Ghostty config (or restart) after pulling to pick up the new bind.