### PR TITLE
Add htop to developer environment

### DIFF
--- a/setup_mac.sh
+++ b/setup_mac.sh
@@ -88,6 +88,9 @@ brew install --cask ghostty
 # Install jq for claude status line
 brew install jq
 
+# Install htop for process monitoring
+brew install htop
+
 # Install context7 MCP for documentation look ups
 claude mcp add --transport http context7 https://mcp.context7.com/mcp
 

--- a/verify_installed_mac_tools.sh
+++ b/verify_installed_mac_tools.sh
@@ -4,6 +4,7 @@ source ~/.bash_profile
 
 TOOLS=(
   claude
+  htop
   lua
   lua-language-server
   node


### PR DESCRIPTION
## Why
Want `htop` available out of the box on a fresh dev machine for process monitoring.

## What
Installs `htop` via Homebrew during `setup_mac.sh` and adds it to the CI verification list.

## How
- [setup_mac.sh](../blob/add-htop/setup_mac.sh): adds `brew install htop`
- [verify_installed_mac_tools.sh](../blob/add-htop/verify_installed_mac_tools.sh): adds `htop` to the `TOOLS` array so CI confirms it lands on `PATH`

## Test plan
- [ ] CircleCI pipeline passes (validates `setup_mac.sh` and tool verification on macOS)