### PR TITLE
Add Obsidian to setup script

### DIFF
--- a/setup_mac.sh
+++ b/setup_mac.sh
@@ -91,6 +91,9 @@ brew install jq
 # Install htop for process monitoring
 brew install htop
 
+# Install Obsidian for note taking
+brew install --cask obsidian
+
 # Install context7 MCP for documentation look ups
 claude mcp add --transport http context7 https://mcp.context7.com/mcp
 


### PR DESCRIPTION
Adds `brew install --cask obsidian` to [`setup_mac.sh`](https://github.com/bmkiefer/dotfiles/blob/add-obsidian/setup_mac.sh#L94-L95) so Obsidian is installed automatically when bootstrapping a new machine.

Not added to [`verify_installed_mac_tools.sh`](https://github.com/bmkiefer/dotfiles/blob/add-obsidian/verify_installed_mac_tools.sh) since Obsidian is a GUI cask with no PATH-accessible binary to verify.

## Test plan
- [ ] CI passes (`setup_mac.sh` runs successfully)
- [ ] Obsidian.app appears in /Applications after running locally