### PR TITLE
Move directory and branch onto a second line in statusline

### DIFF
--- a/claude/statusline.sh
+++ b/claude/statusline.sh
@@ -111,4 +111,4 @@ else
     branch_part=""
 fi
 
-printf "%s %s %s %s %s%s\n" "$model_part" "$sep" "$ctx_part" "$sep" "$dir_part" "$branch_part"
+printf "%s %s %s\n%s%s\n" "$model_part" "$sep" "$ctx_part" "$dir_part" "$branch_part"


### PR DESCRIPTION
The single-line statusline was getting cramped once the model name, context bar, token counts, directory, and branch were all stacked together — especially in worktrees where the directory path is longer. Splitting onto two lines keeps the high-frequency context (model, usage) on top and pushes the location info (directory + branch) onto its own line where it's easier to scan.

The change is a one-line tweak to the final `printf` in [claude/statusline.sh](https://github.com/bmkiefer/dotfiles/blob/statusline-dir-branch-newline/claude/statusline.sh#L114): drop the third separator, insert a newline between the context segment and the directory segment, so the output renders as:

\`\`\`
model │ ctx
~/path/to/dir (branch)
\`\`\`

## Test plan
- [x] Reload Claude Code and confirm the statusline renders across two lines
- [x] Verify in a worktree that the directory path and branch appear on the second line
- [x] Verify a non-git directory still renders cleanly (no trailing branch segment)