### PR TITLE
Make setup_mac.sh idempotent and verify in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,9 @@ jobs:
           name: Run Setup Script
           command: ./setup_mac.sh
       - run:
+          name: Re-run Setup Script (verify idempotency)
+          command: ./setup_mac.sh
+      - run:
           name: Verify Installed Tools
           command: ./verify_installed_mac_tools.sh
 

--- a/setup_mac.sh
+++ b/setup_mac.sh
@@ -38,8 +38,12 @@ fancy_echo "Downloading Git Autocomplete Package..."
 curl https://raw.githubusercontent.com/git/git/master/contrib/completion/git-completion.bash -o ~/.git-completion.bash
 
 # Download and install Homebrew from GitHub
-fancy_echo "Installing Homebrew..."
-/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+if ! command -v brew >/dev/null 2>&1; then
+  fancy_echo "Installing Homebrew..."
+  /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+else
+  fancy_echo "Homebrew already installed, skipping..."
+fi
 
 fancy_echo "Updating Homebrew Packages..."
 brew update --force
@@ -49,8 +53,12 @@ fancy_echo "Installing Neovim..."
 brew install neovim
 
 # Install neovim at newest version
-fancy_echo "Downloading Neovim Config..."
-git clone git@github.com:bmkiefer/nvim-config.git ~/.config/nvim
+if [ ! -d ~/.config/nvim ]; then
+  fancy_echo "Downloading Neovim Config..."
+  git clone git@github.com:bmkiefer/nvim-config.git ~/.config/nvim
+else
+  fancy_echo "Neovim config already cloned, skipping..."
+fi
 
 # Install nvm
 fancy_echo "Installing NVM..."
@@ -95,10 +103,20 @@ brew install htop
 brew install --cask obsidian
 
 # Install context7 MCP for documentation look ups
-claude mcp add --transport http context7 https://mcp.context7.com/mcp
+if ! claude mcp list 2>/dev/null | grep -q '^context7'; then
+  fancy_echo "Adding context7 MCP server..."
+  claude mcp add --transport http context7 https://mcp.context7.com/mcp
+else
+  fancy_echo "context7 MCP already configured, skipping..."
+fi
 
 # Install uv for managing python versions
-curl -LsSf https://astral.sh/uv/install.sh | sh
+if ! command -v uv >/dev/null 2>&1; then
+  fancy_echo "Installing uv..."
+  curl -LsSf https://astral.sh/uv/install.sh | sh
+else
+  fancy_echo "uv already installed, skipping..."
+fi
 
 # resource bash_profile after uv install
 source ~/.bash_profile


### PR DESCRIPTION
Several commands in `setup_mac.sh` errored or redid work when the script was re-run on an already-provisioned machine, which contradicts the "designed to be re-runnable" guidance in [CLAUDE.md](https://github.com/bmkiefer/dotfiles/blob/master/CLAUDE.md). This change makes the script safely re-runnable end to end and wires CI to prove it.

The non-idempotent spots were the [Homebrew installer](https://github.com/bmkiefer/dotfiles/blob/master/setup_mac.sh#L41-L42), the [nvim-config `git clone`](https://github.com/bmkiefer/dotfiles/blob/master/setup_mac.sh#L52-L53) (fails with `destination path already exists`), the [context7 `claude mcp add`](https://github.com/bmkiefer/dotfiles/blob/master/setup_mac.sh#L98) (errors when already registered), and the [uv installer curl pipe](https://github.com/bmkiefer/dotfiles/blob/master/setup_mac.sh#L101) (re-downloads on every run). Each is now wrapped in a `command -v` / directory / `mcp list` check that prints an "already installed, skipping..." message in the else branch, matching the existing `fancy_echo` style.

To keep this from regressing, [.circleci/config.yml](https://github.com/bmkiefer/dotfiles/blob/master/.circleci/config.yml) gains a second `./setup_mac.sh` invocation between the initial run and `verify_installed_mac_tools.sh`, so every pipeline exercises the idempotency guards on a machine where everything is already installed.

## Test plan

- [ ] CircleCI passes — first `setup_mac.sh` run hits install branches, second run hits the skip branches, verify step still finds all tools on `PATH`.
- [ ] Re-run `./setup_mac.sh` locally and confirm no errors plus the four "already installed, skipping..." messages.