### PR TITLE
Fix nvm sourcing in bash_profile across Homebrew architectures

### DIFF
--- a/bash/bash_profile
+++ b/bash/bash_profile
@@ -29,14 +29,21 @@ parse_git_branch() {
 # Customize PS1
 export PS1="[\[\033[38;2;100;255;100m\]\t\[\033[00m\]] \[\033[38;2;255;100;120m\]brandon\[\033[00m\] [\[\033[38;2;100;255;230m\]\w\[\033[00m\]]\[\033[38;2;255;150;255m\]\$(parse_git_branch)\[\033[00m\] $ "
 
-# Add nvm to path
-export NVM_DIR="$HOME/.nvm"
+# Initialize Homebrew so `brew` is on PATH before we use it below.
+# Apple Silicon installs to /opt/homebrew, Intel installs to /usr/local.
+if [ -x /opt/homebrew/bin/brew ]; then
+  eval "$(/opt/homebrew/bin/brew shellenv)"
+elif [ -x /usr/local/bin/brew ]; then
+  eval "$(/usr/local/bin/brew shellenv)"
+fi
 
-# brew --prefix nvm returns the correct Homebrew prefix regardless of architecture (/usr/local on Intel, /opt/homebrew on Apple Silicon).
-# The 2>/dev/null suppresses any error if brew isn't on PATH yet when the profile is sourced.
-NVM_PREFIX="$(brew --prefix nvm 2>/dev/null)"
-  [ -s "$NVM_PREFIX/nvm.sh" ] && . "$NVM_PREFIX/nvm.sh"  # This loads nvm
-  [ -s "$NVM_PREFIX/etc/bash_completion.d/nvm" ] && . "$NVM_PREFIX/etc/bash_completion.d/nvm"  # This loads nvm bash_completion
+# Source nvm from its Homebrew install. HOMEBREW_PREFIX is set by `brew shellenv`
+# above and resolves to the correct arch-specific prefix.
+export NVM_DIR="$HOME/.nvm"
+if [ -n "${HOMEBREW_PREFIX:-}" ] && [ -s "$HOMEBREW_PREFIX/opt/nvm/nvm.sh" ]; then
+  . "$HOMEBREW_PREFIX/opt/nvm/nvm.sh"
+  [ -s "$HOMEBREW_PREFIX/opt/nvm/etc/bash_completion.d/nvm" ] && . "$HOMEBREW_PREFIX/opt/nvm/etc/bash_completion.d/nvm"
+fi
 
 _nvmrc_hook() {
   if [[ $PWD == $PREV_PWD ]]; then


### PR DESCRIPTION
The previous attempt at sourcing nvm via `brew --prefix nvm` returned an empty path on a fresh shell because `brew` wasn't yet on `PATH` when `.bash_profile` was sourced, so nvm never loaded. This change makes nvm sourcing reliable on both Apple Silicon and Intel Macs by initializing Homebrew first, then locating nvm under its arch-specific prefix.

It does this in [`bash/bash_profile`](https://github.com/bmkiefer/dotfiles/blob/bmkiefer/fix-bash-profile/bash/bash_profile#L32-L46) by `eval`ing `brew shellenv` from `/opt/homebrew/bin/brew` (Apple Silicon) or `/usr/local/bin/brew` (Intel), whichever exists, and then sourcing `\$HOMEBREW_PREFIX/opt/nvm/nvm.sh` plus its bash completion. `\$HOMEBREW_PREFIX` is set by `brew shellenv`, so the same lines work on both architectures without branching.

## Test plan
- [x] Sourced locally on Apple Silicon and confirmed `nvm` is available
- [ ] Confirm CI passes