### PR TITLE
Add OrbStack to developer environment setup

### DIFF
--- a/setup_mac.sh
+++ b/setup_mac.sh
@@ -102,6 +102,9 @@ brew install htop
 # Install Obsidian for note taking
 brew install --cask obsidian
 
+# Install OrbStack for containers and VMs
+brew install orbstack
+
 # Install context7 MCP for documentation look ups
 if ! claude mcp list 2>/dev/null | grep -q '^context7'; then
   fancy_echo "Adding context7 MCP server..."


### PR DESCRIPTION
OrbStack is a fast, lightweight way to run Docker containers and Linux VMs on macOS, and it belongs in the baseline development environment so a freshly bootstrapped machine can run containers without extra manual setup.

This adds `brew install orbstack` to `setup_mac.sh`, placed alongside the other application installs like [Obsidian](https://github.com/bmkiefer/dotfiles/blob/add-orbstack/setup_mac.sh#L102-L103).

OrbStack is a GUI cask whose `orb`/`orbctl` CLI tools only land on `PATH` after the app is first launched, so it is not added to the `TOOLS` array in [`verify_installed_mac_tools.sh`](https://github.com/bmkiefer/dotfiles/blob/add-orbstack/verify_installed_mac_tools.sh#L5-L19) — consistent with the other GUI casks (Ghostty, Obsidian, Claude Code) that CI does not verify via `command -v`.